### PR TITLE
Use oldest matching dependency with warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It traverses the full dependency graph (including transitive dependencies) and w
 
 So, more specifically, `bundler-as_of` will try to avoid any releases that were made _after_ the specified date.
 
-Occasionally, `bundler-as_of` may not be able to find a dependency that meets both of these criteria, and in that case will print a warning and will not modify the dependency.
+Occasionally, `bundler-as_of` may not be able to find a dependency that meets both of these criteria. In that case will print a warning and will use the oldest possible dependency.
 
 
 ## Usage


### PR DESCRIPTION
## Background

If the as_of date is too old, we currently revert to the newest version of a dependency. This PR reverts instead to the _oldest_ version of the dependency which is more likely to be compatible.

We do this by instead of returning `nil` on a failure, in both cases we return a version and a boolean indicating whether or not it's an exact match.

This PR also updates the warning with this information.

## Tophatting

For this repo's gemfile, for example, you should get the following output

```
BUNDLE_AS_OF=2013-01-01 bundle install

#=>
NOTE: bundler-as_of: bundling dependencies as of 2013-01-01 ...
NOTE: bundler-as_of: WARNING: could not resolve rake to a version matching ["~> 13.0"] from 2013-01-01
Deferring to rake 10.0.3 from 2012-12-12
NOTE: bundler-as_of: WARNING: could not resolve minitest to a version matching ["~> 5.0"] from 2013-01-01
Deferring to minitest 4.3.3 from 2012-12-07
NOTE: bundler-as_of: WARNING: could not resolve rubocop to a version matching ["~> 1.21"] from 2013-01-01
Deferring to rubocop 0.1.0 from 2012-12-20
NOTE: bundler-as_of: resolving nokogiri [">= 0"] to 1.5.6 released on 2012-12-19
```

## For reviewers

Tophatting is, interesting. But I think I have the main flow working. 

Install the changes:

* `bundler plugin install --git 'bundler-as_of' bundler-as_of `
* ensure plugin is specified in the gemfile

But to test a change I generally have to remove a cache and reinstall? Is that right? Shame I can't just point to a plugin and live test each tweak. e.g.

`rm -rf /Users/schwad/OSS/.bundle/plugin/cache/bundler/git/bundler-as_of-0f51dfbb69835338cd09a29c9c11f0cd09daf1db`

followed by

`bundler plugin install --git 'bundler-as_of' bundler-as_of`

But even now I'm not entirely sure that I'm able to easily chuck my old code and retest my new code. 😨 